### PR TITLE
adjust volume applet to use pulseaudio by default

### DIFF
--- a/basic/skel/.config/lxqt/panel.conf
+++ b/basic/skel/.config/lxqt/panel.conf
@@ -44,8 +44,9 @@ width-percent=true
 
 [panelvolume]
 alignment=Right
-audioEngine=Alsa
-mixerCommand=alsamixer
+audioEngine=PulseAudio
+ignoreMaxVolume=true
+mixerCommand=pavucontrol-qt
 type=panelvolume
 
 [quicklaunch]


### PR DESCRIPTION
if the user installs EVERY package as listed in chrootcfg-systemd.yaml, he also installs pulseaudio. but this break the volume widget in the panel of lxqt. see here for an exemplary post: https://forum.manjaro.org/t/manjaro-lxqt-17-0-net-edition/19023/136

this commit changes the volume applet to use pulseaudio by default. since openrc offers pulseaudio as well, we should change this!